### PR TITLE
优化查歌结果的排版

### DIFF
--- a/maimai.py
+++ b/maimai.py
@@ -138,7 +138,7 @@ async def search_song(bot: NoneBot, ev: CQEvent):
     if len(result) == 0:
         await bot.send(ev, '没有找到这样的乐曲。', at_sender=True)
     elif len(result) < 50:
-        search_result = ''
+        search_result = '\n'
         for music in sorted(result, key=lambda i: int(i['id'])):
             search_result += f'{music["id"]}. {music["title"]}\n'
         await bot.send(ev, search_result.strip(), at_sender=True)

--- a/maimai.py
+++ b/maimai.py
@@ -138,10 +138,10 @@ async def search_song(bot: NoneBot, ev: CQEvent):
     if len(result) == 0:
         await bot.send(ev, '没有找到这样的乐曲。', at_sender=True)
     elif len(result) < 50:
-        search_result = '\n'
+        search_result = ''
         for music in sorted(result, key=lambda i: int(i['id'])):
             search_result += f'{music["id"]}. {music["title"]}\n'
-        await bot.send(ev, search_result.strip(), at_sender=True)
+        await bot.send(ev,'\n' + search_result.strip(), at_sender=True)
     else:
         await bot.send(ev, f'结果过多（{len(result)} 条），请缩小查询范围。', at_sender=True)
 


### PR DESCRIPTION
在@群昵称后换行，防止第一个查歌结果跟在群昵称的后面