### PR TITLE
增加XrayBOT别名库的自动更新支持/更新渠道切换功能

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,3 +15,4 @@ if not os.path.exists(arcades_json):
 arcades: List[Dict] = json.load(open(arcades_json, 'r', encoding='utf-8'))
 
 token = json.load(open(os.path.join(static, 'config.json'), 'r', encoding='utf-8'))['token']
+update_channel = json.load(open(os.path.join(static, 'config.json'), 'r', encoding='utf-8'))['update_channel']

--- a/__init__.py
+++ b/__init__.py
@@ -15,4 +15,3 @@ if not os.path.exists(arcades_json):
 arcades: List[Dict] = json.load(open(arcades_json, 'r', encoding='utf-8'))
 
 token = json.load(open(os.path.join(static, 'config.json'), 'r', encoding='utf-8'))['token']
-update_channel = json.load(open(os.path.join(static, 'config.json'), 'r', encoding='utf-8'))['update_channel']

--- a/libraries/maimaidx_api_data.py
+++ b/libraries/maimaidx_api_data.py
@@ -19,6 +19,7 @@ ALIAS = {
     'end': 'GetAliasEnd'
 }
 
+
 async def get_player_data(project: str, payload: dict) -> Union[dict, str]:
     """
     获取用户数据，获取失败时返回字符串
@@ -34,7 +35,8 @@ async def get_player_data(project: str, payload: dict) -> Union[dict, str]:
     else:
         return '项目错误'
     try:
-        async with aiohttp.request('POST', f'{maimaiapi}/query/{p}', json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('POST', f'{maimaiapi}/query/{p}', json=payload,
+                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = player_error
             elif resp.status == 403:
@@ -48,9 +50,11 @@ async def get_player_data(project: str, payload: dict) -> Union[dict, str]:
         data = f'获取玩家数据时发生错误，请联系BOT管理员: {type(e)}'
     return data
 
+
 async def get_dev_player_data(payload: dict) -> Union[dict, str]:
     try:
-        async with aiohttp.request('GET', f'{maimaiapi}/dev/player/records', headers={'developer-token': token}, params=payload) as resp:
+        async with aiohttp.request('GET', f'{maimaiapi}/dev/player/records', headers={'developer-token': token},
+                                   params=payload) as resp:
             if resp.status == 400:
                 data = player_error
             elif resp.status == 403:
@@ -63,13 +67,15 @@ async def get_dev_player_data(payload: dict) -> Union[dict, str]:
         log.error(f'Error: {traceback.format_exc()}')
         data = f'获取玩家数据时发生错误，请联系BOT管理员: {type(e)}'
     return data
+
 
 async def get_rating_ranking_data() -> Union[dict, str]:
     """
     获取排名，获取失败时返回字符串
     """
     try:
-        async with aiohttp.request('GET', f'{maimaiapi}/rating_ranking', timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('GET', f'{maimaiapi}/rating_ranking',
+                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status != 200:
                 data = '未知错误，请联系BOT管理员'
             else:
@@ -79,7 +85,9 @@ async def get_rating_ranking_data() -> Union[dict, str]:
         data = f'获取排名时发生错误，请联系BOT管理员: {type(e)}'
     return data
 
-async def get_music_alias(api: str, params: dict = None) -> Union[List[Dict[str, Union[str, int, List[str]]]], Dict[str, Union[str, int, List[str]]]]:
+
+async def get_music_alias(api: str, params: dict = None) -> Union[
+    List[Dict[str, Union[str, int, List[str]]]], Dict[str, Union[str, int, List[str]]]]:
     """
     - `all`: 所有曲目的别名
     - `songs`: 该别名的曲目
@@ -88,7 +96,8 @@ async def get_music_alias(api: str, params: dict = None) -> Union[List[Dict[str,
     - `end`: 已结束的别名申请
     """
     try:
-        async with aiohttp.request('GET', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('GET', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params,
+                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = '参数输入错误'
             elif resp.status == 500:
@@ -100,13 +109,30 @@ async def get_music_alias(api: str, params: dict = None) -> Union[List[Dict[str,
         data = f'获取别名时发生错误，请联系BOT管理员: {type(e)}'
     return data
 
-async def post_music_alias(api: str, params: dict = None) -> Union[List[Dict[str, Union[str, int, List[str]]]], Dict[str, Union[str, int, List[str]]]]:
+
+async def get_xray_alias() -> Union[list, str]:
+    try:
+        async with aiohttp.request('GET', f'https://download.fanyu.site/maimai/alias.json',
+                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+            if resp.status != 200:
+                data = '别名服务器错误，请联系Xray Bot开发者'
+            else:
+                data = await resp.json()
+    except Exception as e:
+        log.error(f'Error: {traceback.format_exc()}')
+        data = f'获取别名时发生错误，请联系BOT管理员: {type(e)}'
+    return data
+
+
+async def post_music_alias(api: str, params: dict = None) -> Union[
+    List[Dict[str, Union[str, int, List[str]]]], Dict[str, Union[str, int, List[str]]]]:
     """
     - `apply`: 申请别名
     - `agree`: 同意别名
     """
     try:
-        async with aiohttp.request('POST', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('POST', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params,
+                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = '参数输入错误'
             elif resp.status == 500:

--- a/libraries/maimaidx_api_data.py
+++ b/libraries/maimaidx_api_data.py
@@ -106,19 +106,6 @@ async def get_music_alias(api: str, params: dict = None) -> Union[
     return data
 
 
-async def get_xray_alias() -> Union[list, str]:
-    try:
-        async with aiohttp.request('GET', f'https://download.fanyu.site/maimai/alias.json', timeout=aiohttp.ClientTimeout(total=30)) as resp:
-            if resp.status != 200:
-                data = '别名服务器错误，请联系Xray Bot开发者'
-            else:
-                data = await resp.json()
-    except Exception as e:
-        log.error(f'Error: {traceback.format_exc()}')
-        data = f'获取别名时发生错误，请联系BOT管理员: {type(e)}'
-    return data
-
-
 async def post_music_alias(api: str, params: dict = None) -> Union[
     List[Dict[str, Union[str, int, List[str]]]], Dict[str, Union[str, int, List[str]]]]:
     """

--- a/libraries/maimaidx_api_data.py
+++ b/libraries/maimaidx_api_data.py
@@ -35,8 +35,7 @@ async def get_player_data(project: str, payload: dict) -> Union[dict, str]:
     else:
         return '项目错误'
     try:
-        async with aiohttp.request('POST', f'{maimaiapi}/query/{p}', json=payload,
-                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('POST', f'{maimaiapi}/query/{p}', json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = player_error
             elif resp.status == 403:
@@ -53,8 +52,7 @@ async def get_player_data(project: str, payload: dict) -> Union[dict, str]:
 
 async def get_dev_player_data(payload: dict) -> Union[dict, str]:
     try:
-        async with aiohttp.request('GET', f'{maimaiapi}/dev/player/records', headers={'developer-token': token},
-                                   params=payload) as resp:
+        async with aiohttp.request('GET', f'{maimaiapi}/dev/player/records', headers={'developer-token': token}, params=payload) as resp:
             if resp.status == 400:
                 data = player_error
             elif resp.status == 403:
@@ -74,8 +72,7 @@ async def get_rating_ranking_data() -> Union[dict, str]:
     获取排名，获取失败时返回字符串
     """
     try:
-        async with aiohttp.request('GET', f'{maimaiapi}/rating_ranking',
-                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('GET', f'{maimaiapi}/rating_ranking', timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status != 200:
                 data = '未知错误，请联系BOT管理员'
             else:
@@ -96,8 +93,7 @@ async def get_music_alias(api: str, params: dict = None) -> Union[
     - `end`: 已结束的别名申请
     """
     try:
-        async with aiohttp.request('GET', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params,
-                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('GET', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params, timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = '参数输入错误'
             elif resp.status == 500:
@@ -112,8 +108,7 @@ async def get_music_alias(api: str, params: dict = None) -> Union[
 
 async def get_xray_alias() -> Union[list, str]:
     try:
-        async with aiohttp.request('GET', f'https://download.fanyu.site/maimai/alias.json',
-                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('GET', f'https://download.fanyu.site/maimai/alias.json', timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status != 200:
                 data = '别名服务器错误，请联系Xray Bot开发者'
             else:
@@ -131,8 +126,7 @@ async def post_music_alias(api: str, params: dict = None) -> Union[
     - `agree`: 同意别名
     """
     try:
-        async with aiohttp.request('POST', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params,
-                                   timeout=aiohttp.ClientTimeout(total=30)) as resp:
+        async with aiohttp.request('POST', f'https://api.yuzuai.xyz/maimaidx/{ALIAS[api]}', params=params, timeout=aiohttp.ClientTimeout(total=30)) as resp:
             if resp.status == 400:
                 data = '参数输入错误'
             elif resp.status == 500:

--- a/libraries/maimaidx_music.py
+++ b/libraries/maimaidx_music.py
@@ -359,7 +359,7 @@ async def get_local_music_list() -> MusicList:
 
 
 async def get_local_music_alias_list() -> AliasList:
-    if os.path.isfile(os.path.join(static, 'chart_stats.json')):
+    if os.path.isfile(os.path.join(static, 'all_alias.json')):
         async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'r', encoding='utf-8') as f:
             data = json.loads(await f.read())
     else:

--- a/libraries/maimaidx_music.py
+++ b/libraries/maimaidx_music.py
@@ -9,15 +9,14 @@ from typing import Dict, List, Optional, Tuple, Union
 import aiofiles
 import aiohttp
 from PIL import Image
-from numpy.core.defchararray import upper
 from pydantic import BaseModel, Field
 
-from .. import log, static, update_channel
+from .. import log, static
 from .image import image_to_base64
 from .maimaidx_api_data import *
 
 cover_dir = os.path.join(static, 'mai', 'cover')
-
+alias_file = os.path.join(static, 'all_alias.json')
 
 class Stats(BaseModel):
 
@@ -178,53 +177,18 @@ def search_charts(checker: List[Chart], elem: str, diff: List[int]):
     return ret, diff_ret
 
 
-async def parse_xray_data(xray_data):
-    if os.path.isfile(os.path.join(static, 'all_alias.json')):
-        async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'r', encoding='utf-8') as f:
-            origin = json.loads(await f.read())
-    else:
-        '''
-        防最新最热装置(防止因为缺少all_alias.json报错)
-        '''
-        origin = await get_music_alias('all')
-    for keys in xray_data:
-        if len(xray_data[keys]) != 0:
-            for song_id in xray_data[keys]:
-                if song_id in origin:
-                    if keys not in origin[song_id]["Alias"]:
-                        origin[song_id]["Alias"].append(keys)
-    log.info('Xray别名库合并完成, yoooo↗')
-    return origin
-
-
-async def merge_local_alias(remote_data):
-    async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'r', encoding='utf-8') as f:
-        origin = json.loads(await f.read())
-        '''
-        读取原始数据进行合并操作, 防止覆盖已有数据
-        '''
-    for key in remote_data:
-        if key in origin:
-            origin[key]["Alias"] = list(set(origin[key]["Alias"] + remote_data[key]["Alias"]))
-    log.info('官方别名库合并完成, yoooo↗')
-    return origin
-
-
 class Alias(BaseModel):
 
-    ID: Optional[int] = None
+    ID: Optional[str] = None
     Name: Optional[str] = None
     Alias: Optional[List[str]] = None
 
-
 class AliasList(List[Alias]):
 
-    def by_id(self, music_id: int) -> Optional[List[Alias]]:
-        alias_list = []
+    def by_id(self, music_id: str) -> Optional[Alias]:
         for music in self:
-            if music.ID == int(music_id):
-                alias_list.append(music)
-        return alias_list
+            if music.ID == music_id:
+                return music
     
     def by_alias(self, music_alias: str) -> Optional[List[Alias]]:
         alias_list = []
@@ -292,26 +256,35 @@ async def get_music_list() -> MusicList:
 
     return total_list
 
-
 async def get_music_alias_list() -> AliasList:
     """
     获取所有别名
     """
-    data = await get_music_alias('all') if upper(update_channel) != 'XRAY' else await get_xray_alias()
-    if isinstance(data, str):
-        log.info('获取所有曲目别名信息错误，请检查网络环境。已切换至本地暂存文件')
-        async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'r', encoding='utf-8') as f:
-            data = json.loads(await f.read())
+    if os.path.exists(alias_file):
+        async with aiofiles.open(alias_file, 'r', encoding='utf-8') as f:
+            local_alias_data: Dict[str, Dict[str, Union[str, List[str]]]] = json.loads(await f.read())
     else:
-        if upper(update_channel) == 'XRAY':
-            data = parse_xray_data(data)
-            log.info('当前使用的曲目别名信息库由 XrayBot 提供')
-        else:
-            if os.path.isfile(os.path.join(static, 'all_alias.json')):
-                data = await merge_local_alias(data)
-            log.info('当前使用官方的曲目别名信息库')
-        async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'w', encoding='utf-8') as f:
-            await f.write(json.dumps(data, ensure_ascii=False, indent=4))
+        local_alias_data = {}
+    
+    alias_data: Dict[str, Dict[str, Union[str, List[str]]]] = await get_music_alias('all')
+    if isinstance(alias_data, str):
+        log.error('获取所有曲目别名信息错误，请检查网络环境。已切换至本地暂存文件')
+        if not local_alias_data:
+            log.error('本地暂存别名文件为空，请自行使用浏览器访问 "https://api.yuzuai.xyz/maimaidx/maimaidxalias" 获取别名数据并保存在 "static/all_alias.json" 文件中')
+    else:
+        for id, music in alias_data.items():
+            if id in local_alias_data:
+                for alias_name in music['Alias']:
+                    if alias_name.lower() not in local_alias_data[id]['Alias']:
+                        local_alias_data[id]['Alias'].append(alias_name.lower())
+            else:
+                local_alias_data[id] = {
+                    'Name': music['Name'],
+                    'Alias': music['Alias']
+                }
+        async with aiofiles.open(alias_file, 'w', encoding='utf-8') as f:
+            await f.write(json.dumps(local_alias_data, ensure_ascii=False, indent=4))
+    data = local_alias_data
     
     total_alias_list = AliasList(data)
     for _ in range(len(total_alias_list)):
@@ -319,57 +292,27 @@ async def get_music_alias_list() -> AliasList:
 
     return total_alias_list
 
-
-async def get_local_music_list() -> MusicList:
-    if os.path.isfile(os.path.join(static, 'music_data.json')):
-        log.info('当前使用离线模式，跳过曲目数据和别名更新')
-        async with aiofiles.open(os.path.join(static, 'music_data.json'), 'r', encoding='utf-8') as f:
-                data = json.loads(await f.read())
-    else:
-        log.info('本地还没有曲目数据, 正在联网获取.')
-        async with aiohttp.request('GET', 'https://www.diving-fish.com/api/maimaidxprober/music_data', timeout=aiohttp.ClientTimeout(total=30)) as obj_data:
-            if obj_data.status != 200:
-                log.error('maimaiDX曲目数据获取失败，请检查网络环境。')
-            else:
-                data = await obj_data.json()
-                async with aiofiles.open(os.path.join(static, 'music_data.json'), 'w', encoding='utf-8') as f:
-                    await f.write(json.dumps(data, ensure_ascii=False, indent=4))
-
-    if os.path.isfile(os.path.join(static, 'chart_stats.json')):
-        async with aiofiles.open(os.path.join(static, 'chart_stats.json'), 'r', encoding='utf-8') as f:
-                stats = json.loads(await f.read())
-    else:
-        log.info('本地还没有曲目统计信息, 正在联网获取.')
-        async with aiohttp.request('GET', 'https://www.diving-fish.com/api/maimaidxprober/chart_stats', timeout=aiohttp.ClientTimeout(total=30)) as obj_stats:
-            if obj_stats.status != 200:
-                log.error('maimaiDX数据获取错误，请检查网络环境。')
-            else:
-                stats = await obj_stats.json()
-                async with aiofiles.open(os.path.join(static, 'chart_stats.json'), 'w', encoding='utf-8') as f:
-                    await f.write(json.dumps(stats, ensure_ascii=False, indent=4))
-    total_list: MusicList = MusicList(data)
-    for num, music in enumerate(total_list):
-        if music['id'] in stats['charts']:
-            _stats = stats['charts'][music['id']]
-        else:
-            _stats = None
-        total_list[num] = Music(stats=_stats, **total_list[num])
-
-    return total_list
-
-
-async def get_local_music_alias_list() -> AliasList:
-    if os.path.isfile(os.path.join(static, 'all_alias.json')):
-        async with aiofiles.open(os.path.join(static, 'all_alias.json'), 'r', encoding='utf-8') as f:
-            data = json.loads(await f.read())
-    else:
-        data = await get_music_alias('all')
-    total_alias_list = AliasList(data)
-    for _ in range(len(total_alias_list)):
-        total_alias_list[_] = Alias(ID=total_alias_list[_], Name=data[total_alias_list[_]]['Name'], Alias=data[total_alias_list[_]]['Alias'])
-
-    return total_alias_list
-
+async def update_local_alias(id: str, alias_name: str):
+    try:
+        async with aiofiles.open(alias_file, 'r', encoding='utf-8') as f:
+            local_alias_data: Dict[str, Dict[str, Union[str, List[str]]]] = json.loads(await f.read())
+            
+        music_alias = mai.total_alias_list.by_id(id)
+        index = mai.total_alias_list.index(music_alias)
+        new_list = music_alias.Alias
+        new_list.append(alias_name)
+        new_alias = {
+            'Name': music_alias.Name,
+            'Alias': new_list
+        }
+        mai.total_alias_list[index] = Alias(ID=int(id), **new_alias)
+        local_alias_data[id]['Alias'] = new_list
+        async with aiofiles.open(alias_file, 'w', encoding='utf-8') as f:
+                await f.write(json.dumps(local_alias_data, ensure_ascii=False, indent=4))
+        return True
+    except Exception as e:
+        log.error('添加本地别名失败')
+        return False
 
 class MaiMusic:
 
@@ -384,13 +327,13 @@ class MaiMusic:
         """
         获取所有曲目数据
         """
-        self.total_list = await get_music_list() if upper(update_channel)!='OFFLINE' else await get_local_music_list()
+        self.total_list = await get_music_list()
 
     async def get_music_alias(self) -> AliasList:
         """
         获取所有曲目别名
         """
-        self.total_alias_list = await get_music_alias_list() if upper(update_channel)!='OFFLINE' else await get_local_music_alias_list()
+        self.total_alias_list = await get_music_alias_list()
 
     def guess(self):
         """

--- a/maimai.py
+++ b/maimai.py
@@ -13,7 +13,7 @@ from hoshino.typing import CommandSession, CQEvent, MessageSegment
 from . import *
 from .libraries.image import *
 from .libraries.maimaidx_api_data import *
-from .libraries.maimaidx_music import alias, guess, mai
+from .libraries.maimaidx_music import alias, guess, mai, update_local_alias
 from .libraries.maimaidx_project import *
 from .libraries.tool import *
 
@@ -340,6 +340,25 @@ async def how_song(bot: NoneBot, ev: CQEvent):
     msg += '\n'.join(alias[0].Alias)
     await bot.send(ev, msg, at_sender=True)
 
+@sv.on_prefix(['添加本地别名', '添加本地别称'])
+async def apply_local_alias(bot: NoneBot, ev: CQEvent):
+    args: list[str] = ev.message.extract_plain_text().strip().split()
+    id, alias_name = args
+    if not mai.total_list.by_id(id):
+        await bot.finish(ev, f'未找到ID为 [{id}] 的曲目')
+    server_exist = await get_music_alias('alias', {'id': id})
+    if alias_name in server_exist[id]:
+        await bot.finish(ev, f'该曲目的别名 <{alias_name}> 已存在别名服务器，不能重复添加别名，如果bot未生效，请联系BOT管理员使用指令 <更新别名库>')
+    local_exist = mai.total_alias_list.by_alias(alias_name)
+    if local_exist:
+        await bot.finish(ev, f'本地别名库已存在该别名', at_sender=True)
+    issave = await update_local_alias(id, alias_name)
+    if not issave:
+        msg = '添加本地别名失败'
+    else:
+        msg = f'已成功为ID <{id}> 添加别名 <{alias_name}> 到本地别名库'
+    await bot.send(ev, msg, at_sender=True)
+
 @sv.on_prefix(['添加别名', '增加别名', '增添别名', '添加别称'])
 async def apply_alias(bot: NoneBot, ev: CQEvent):
     args: list[str] = ev.message.extract_plain_text().strip().split()
@@ -352,7 +371,7 @@ async def apply_alias(bot: NoneBot, ev: CQEvent):
         await bot.finish(ev, f'未找到ID为 [{id}] 的曲目')
     isexist = await get_music_alias('alias', {'id': id})
     if alias_name in isexist[id]:
-        await bot.finish(ev, f'该曲目的别名 <{alias_name}> 已存在，不能重复添加别名')
+        await bot.finish(ev, f'该曲目的别名 <{alias_name}> 已存在，不能重复添加别名，如果bot未生效，请联系BOT管理员使用指令 <更新别名库>')
     tag = ''.join(sample(ascii_uppercase + digits, 5))
     status = await post_music_alias('apply', {'id': id, 'aliasname': alias_name, 'tag': tag, 'uid': ev.user_id})
     if 'error' in status:
@@ -428,6 +447,10 @@ async def _(session: CommandSession):
         await session.send('已全局开启maimai别名推送')
     else:
         return
+    
+@sucmd('updatealias', aliases=('更新别名库'))
+async def _(session: CommandSession):
+    await mai.get_music_alias()
 
 @sv.scheduled_job('interval', minutes=5)
 async def alias_apply_status():

--- a/maimai.py
+++ b/maimai.py
@@ -450,7 +450,13 @@ async def _(session: CommandSession):
     
 @sucmd('updatealias', aliases=('更新别名库'))
 async def _(session: CommandSession):
-    await mai.get_music_alias()
+    try:
+        await mai.get_music_alias()
+        log.error('手动更新别名库成功')
+        await session.send('手动更新别名库成功')
+    except:
+        log.error('手动更新别名库失败')
+        await session.send('手动更新别名库失败')
 
 @sv.scheduled_job('interval', minutes=5)
 async def alias_apply_status():

--- a/static/config.json
+++ b/static/config.json
@@ -1,4 +1,4 @@
 {
     "token": "",
-    "update_channel": "OFFLINE"
+    "update_channel": "OFFICIAL"
 }

--- a/static/config.json
+++ b/static/config.json
@@ -1,3 +1,4 @@
 {
-    "token": ""
+    "token": "",
+    "update_channel": "OFFLINE"
 }

--- a/static/config.json
+++ b/static/config.json
@@ -1,4 +1,3 @@
 {
-    "token": "",
-    "update_channel": "OFFICIAL"
+    "token": ""
 }


### PR DESCRIPTION
### 已实现的功能:
现在可以通过编辑/static/config.json中的`update_channel`选择更新渠道了.
别名库能够去重合并同时忽略空数据了.
可以选择离线模式从而提高启动速度了.

### 如何使用?
`现在可以通过编辑/static/config.json中的`update_channel`选择更新渠道了.`

可选的更新渠道如下:
- XRAY
- OFFLINE
- OFFICIAL

> XRAY - 使用XrayBOT的别名库
> OFFLINE - 使用离线模式，直接读取本地文件，调试其他插件/想自己编辑别名库的有福了
> OFFICIAL(或者其他内容) - 使用Yuzuai提供的默认接口更新别名库

config.json的一个示例：
```
{
    "token": "",
    "update_channel": "XRAY"
}
```


如果是之前部署过本插件的用户，可直接升级
如果是首次部署，建议先通过OFFICIAL通道更新一次再切换Xray(已经做了防最新最热装置，就算首次就切换了Xray也会默认从OFFICIAL通道下载一次)