### PR TITLE
修复 rank C 时提示缺失文件报错

### DIFF
--- a/libraries/maimai_best_50.py
+++ b/libraries/maimai_best_50.py
@@ -241,7 +241,7 @@ class DrawBest:
         rating = Image.open(os.path.join(self.maimai_dir, 'UI_CMN_Shougou_Rainbow.png')).resize((454, 50))
         self._diff = [basic, advanced, expert, master, remaster]
         self.dxstar = [Image.open(os.path.join(self.maimai_dir, f'UI_RSL_DXScore_Star_0{_ + 1}.png')).resize((20, 20)) for _ in range(3)]
-        self.rank = {'d': 'D', 'c': 'c', 'b': 'B', 'bb': 'BB', 'bbb': 'BBB', 'a': 'A', 'aa': 'AA', 'aaa': 'AAA', 's': 'S', 'sp': 'Sp', 'ss': 'SS', 'ssp': 'SSp', 'sss': 'SSS', 'sssp': 'SSSp'}
+        self.rank = {'d': 'D', 'c': 'C', 'b': 'B', 'bb': 'BB', 'bbb': 'BBB', 'a': 'A', 'aa': 'AA', 'aaa': 'AAA', 's': 'S', 'sp': 'Sp', 'ss': 'SS', 'ssp': 'SSp', 'sss': 'SSS', 'sssp': 'SSSp'}
         self.fcl = {'fc': 'FC', 'fcp': 'FCp', 'ap': 'AP', 'app': 'APp'}
         self.fsl = {'fs': 'FS', 'fsp': 'FSp', 'fsd': 'FSD', 'fsdp': 'FSDp'}
 


### PR DESCRIPTION
报错如图所示

![682dbfc6bc61d18109365329a5b165be](https://github.com/Yuri-YuzuChaN/maimaiDX/assets/44129124/e2211b41-557d-4c1d-9da2-5dd90fb53a01)

修复了在包含rank C的分数时获取b50出现缺失文件报错的问题。