### PR TITLE
fix: 修复指令、机厅排卡与核心逻辑的多个 bug

### DIFF
--- a/commands/depend.py
+++ b/commands/depend.py
@@ -74,6 +74,14 @@ GetUserAndAuthOrNone = GetUserModel(auto_create=True, check_auth=True, check_ski
 
 
 
+def _isfloat(value: str) -> bool:
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
 async def process_regex(bot: NoneBot, ev: CQEvent) -> tuple[list[Song], int]:
     """
     查歌指令依赖注入函数，返回曲目列表以及页数
@@ -89,80 +97,84 @@ async def process_regex(bot: NoneBot, ev: CQEvent) -> tuple[list[Song], int]:
     page = 1
     match cmd:
         case None:
-            match a_list:
-                case [name]:
-                    title = name
-                case [name, p_raw]:
-                    title, page = name, int(p_raw)
-                case _:
-                    await bot.finish(
-                        ev, 
-                        "没有找到这样的乐曲。\n※ 如果是别名请使用「XXX是什么歌」指令进行查询哦。",
-                        reply_message=True,
-                    )
+            if not a_list:
+                await bot.finish(
+                    ev,
+                    "没有找到这样的乐曲。\n※ 如果是别名请使用「XXX是什么歌」指令进行查询哦。",
+                    at_sender=True,
+                )
+            # 末尾为纯数字时视为页数，其余整体作为标题（支持含空格的标题）
+            if len(a_list) >= 2 and a_list[-1].isdigit():
+                title, page = " ".join(a_list[:-1]), int(a_list[-1])
+            else:
+                title = " ".join(a_list)
             result = mai.total_list.filter(title=title)
         case "定数":
             match a_list:
-                case [ds]:
+                case [ds] if _isfloat(ds):
                     ds1 = ds2 = float(ds)
-                case [ds1_raw, ds2_raw]:
+                case [ds1_raw, ds2_raw] if _isfloat(ds1_raw) and _isfloat(ds2_raw):
                     ds1, ds2 = float(ds1_raw), float(ds2_raw)
-                case [ds1_raw, ds2_raw, p_raw]:
+                case [ds1_raw, ds2_raw, p_raw] if (
+                    _isfloat(ds1_raw) and _isfloat(ds2_raw) and p_raw.isdigit()
+                ):
                     ds1, ds2, page = float(ds1_raw), float(ds2_raw), int(p_raw)
                 case _:
                     await bot.finish(
-                        ev, 
+                        ev,
                         (
                             "定数查歌参数错误，请输入正确格式，页数为可选：\n"
                             "定数查歌「定数」「页数」\n"
                             "定数查歌「最小定数」「最大定数」「页数」\n"
                         ),
-                        reply_message=True,
+                        at_sender=True,
                     )
             result = mai.total_list.filter(level_value=(ds1, ds2))
         case "bpm":
             match a_list:
-                case [bpm_raw]:
+                case [bpm_raw] if _isfloat(bpm_raw):
                     result = mai.total_list.filter(bpm=float(bpm_raw))
-                case [b1, b2]:
+                case [b1, b2] if _isfloat(b1) and _isfloat(b2):
                     if float(b1) > float(b2):
-                        page = int(b2)
+                        page = int(float(b2))
                         result = mai.total_list.filter(bpm=float(b1))
                     else:
                         result = mai.total_list.filter(bpm=(float(b1), float(b2)))
-                case [b1, b2, p_raw]:
+                case [b1, b2, p_raw] if (
+                    _isfloat(b1) and _isfloat(b2) and p_raw.isdigit()
+                ):
                     result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                     page = int(p_raw)
                 case _:
                     await bot.finish(
-                        ev, 
+                        ev,
                         (
                             "bpm查歌参数错误，请输入正确格式，页数为可选：\n"
                             "bpm查歌「bpm」「页数」\n"
                             "bpm查歌「最小bpm」「最大bpm」「页数」\n"
                         ),
-                        reply_message=True,
+                        at_sender=True,
                     )
         case "曲师" | "谱师":
-            match a_list:
-                case [name]:
-                    pass
-                case [name, p_raw] if p_raw.isdigit():
-                    page = int(p_raw)
-                case _:
-                    await bot.finish(
-                        ev, 
-                        (
-                            f"{cmd}查歌参数错误，请输入正确格式，页数为可选：\n"
-                            f"{cmd}查歌「{cmd}」「页数」"
-                        ),
-                        reply_message=True,
-                    )
+            if not a_list:
+                await bot.finish(
+                    ev,
+                    (
+                        f"{cmd}查歌参数错误，请输入正确格式，页数为可选：\n"
+                        f"{cmd}查歌「{cmd}」「页数」"
+                    ),
+                    at_sender=True,
+                )
+            # 末尾为纯数字时视为页数，其余整体作为曲师/谱师名（支持含空格的名字）
+            if len(a_list) >= 2 and a_list[-1].isdigit():
+                name, page = " ".join(a_list[:-1]), int(a_list[-1])
+            else:
+                name = " ".join(a_list)
             if cmd == "曲师":
                 result = mai.total_list.filter(artist=name)
             else:
                 result = mai.total_list.filter(charter=name)
         case _:
-            await bot.finish(ev, "指令错误", reply_message=True)
+            await bot.finish(ev, "指令错误", at_sender=True)
 
     return result, page

--- a/commands/depend.py
+++ b/commands/depend.py
@@ -74,7 +74,7 @@ GetUserAndAuthOrNone = GetUserModel(auto_create=True, check_auth=True, check_ski
 
 
 
-def _isfloat(value: str) -> bool:
+def is_float(value: str) -> bool:
     try:
         float(value)
         return True
@@ -111,12 +111,12 @@ async def process_regex(bot: NoneBot, ev: CQEvent) -> tuple[list[Song], int]:
             result = mai.total_list.filter(title=title)
         case "定数":
             match a_list:
-                case [ds] if _isfloat(ds):
+                case [ds] if is_float(ds):
                     ds1 = ds2 = float(ds)
-                case [ds1_raw, ds2_raw] if _isfloat(ds1_raw) and _isfloat(ds2_raw):
+                case [ds1_raw, ds2_raw] if is_float(ds1_raw) and is_float(ds2_raw):
                     ds1, ds2 = float(ds1_raw), float(ds2_raw)
                 case [ds1_raw, ds2_raw, p_raw] if (
-                    _isfloat(ds1_raw) and _isfloat(ds2_raw) and p_raw.isdigit()
+                    is_float(ds1_raw) and is_float(ds2_raw) and p_raw.isdigit()
                 ):
                     ds1, ds2, page = float(ds1_raw), float(ds2_raw), int(p_raw)
                 case _:
@@ -132,16 +132,16 @@ async def process_regex(bot: NoneBot, ev: CQEvent) -> tuple[list[Song], int]:
             result = mai.total_list.filter(level_value=(ds1, ds2))
         case "bpm":
             match a_list:
-                case [bpm_raw] if _isfloat(bpm_raw):
+                case [bpm_raw] if is_float(bpm_raw):
                     result = mai.total_list.filter(bpm=float(bpm_raw))
-                case [b1, b2] if _isfloat(b1) and _isfloat(b2):
+                case [b1, b2] if is_float(b1) and is_float(b2):
                     if float(b1) > float(b2):
                         page = int(float(b2))
                         result = mai.total_list.filter(bpm=float(b1))
                     else:
                         result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                 case [b1, b2, p_raw] if (
-                    _isfloat(b1) and _isfloat(b2) and p_raw.isdigit()
+                    is_float(b1) and is_float(b2) and p_raw.isdigit()
                 ):
                     result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                     page = int(p_raw)

--- a/commands/mai_alias.py
+++ b/commands/mai_alias.py
@@ -22,8 +22,10 @@ alias_apply = sv.on_prefix(["添加别名", "增加别名", "增添别名", "添
 alias_agree = sv.on_prefix(["同意别名", "同意别称"])
 alias_status = sv.on_prefix(["当前投票", "当前别名投票", "当前别称投票"])
 alias_switch = sv.on_suffix(["别名推送", "别称推送"])
-alias_global_switch = sv.on_rex(r"^全局([开启关闭]+)别名推送$")
-alias_song = sv.on_rex(re.compile(r"^(id)?\s?(.+)\s?有什么别[名称]$", re.IGNORECASE))
+alias_global_switch = sv.on_rex(r"^全局(开启|关闭)别名推送$")
+alias_song = sv.on_rex(
+    re.compile(r"^(id(?=[\s0-9]))?\s?(.+)\s?有什么别[名称]$", re.IGNORECASE)
+)
 
 
 @update_alias
@@ -108,7 +110,7 @@ async def _(bot: NoneBot, ev: CQEvent):
                 ev, f"该曲目的别名「{alias_name}」已存在别名服务器", at_sender=True
             )
 
-        msg = await api.post_alias(song_id, alias_name, ev.user_id, ev.group_id)
+        msg = (await api.post_alias(song_id, alias_name, ev.user_id, ev.group_id)).message
     except Exception as e:
         log.error(traceback.format_exc())
         msg = str(e)
@@ -121,9 +123,11 @@ async def _(bot: NoneBot, ev: CQEvent):
         tag: str = ev.message.extract_plain_text().strip().upper()
         api = YuzuChaNAPI()
         status = await api.post_agree_user(tag, ev.user_id)
-        await bot.send(ev, status, at_sender=True)
-    except ValueError as e:
-        await bot.send(ev, str(e), at_sender=True)
+        msg = status.message
+    except Exception as e:
+        log.error(traceback.format_exc())
+        msg = str(e)
+    await bot.send(ev, msg, at_sender=True)
 
 
 @alias_status
@@ -135,7 +139,8 @@ async def _(bot: NoneBot, ev: CQEvent):
         if not status:
             await bot.finish(ev, "未查询到正在进行的别名投票", at_sender=True)
 
-        page = max(min(int(args), len(status) // SONGS_PER_PAGE + 1), 1) if args else 1
+        total_pages = (len(status) + SONGS_PER_PAGE - 1) // SONGS_PER_PAGE
+        page = max(min(int(args), total_pages), 1) if args.isdigit() else 1
         result = []
         for num, _s in enumerate(status):
             if (page - 1) * SONGS_PER_PAGE <= num < page * SONGS_PER_PAGE:
@@ -150,7 +155,7 @@ async def _(bot: NoneBot, ev: CQEvent):
                         - 票数：{_s.agree_votes}/{_s.votes}
                     """)
                 )
-        result.append(f"第「{page}」页，共「{len(status) // SONGS_PER_PAGE + 1}」页")
+        result.append(f"第「{page}」页，共「{total_pages}」页")
         msg = MessageSegment.image(text_to_bytes_io("\n".join(result)))
     except (ServerError, ValueError) as e:
         log.error(traceback.format_exc())
@@ -165,7 +170,7 @@ async def _(bot: NoneBot, ev: CQEvent):
     name = match.group(2).lower()
     aliases = None
     if findid and name.isdigit():
-        alias_id = mai.total_alias_list.by_id(name)
+        alias_id = mai.total_alias_list.by_id(int(name))
         if not alias_id:
             await bot.finish(
                 ev,
@@ -178,7 +183,7 @@ async def _(bot: NoneBot, ev: CQEvent):
         aliases = mai.total_alias_list.by_alias(name)
         if not aliases:
             if name.isdigit():
-                alias_id = mai.total_alias_list.by_id(name)
+                alias_id = mai.total_alias_list.by_id(int(name))
                 if not alias_id:
                     await bot.finish(
                         ev,
@@ -204,11 +209,14 @@ async def _(bot: NoneBot, ev: CQEvent):
             at_sender=True,
         )
 
-    if len(aliases[0].alias) == 1:
+    real_aliases = [
+        a for a in aliases[0].alias if a.lower() != aliases[0].song_name.lower()
+    ]
+    if not real_aliases:
         await bot.finish(ev, "该曲目没有别名", at_sender=True)
 
     msg = f"该曲目有以下别名：\nID：{aliases[0].song_id}\n"
-    msg += "\n".join(aliases[0].alias)
+    msg += "\n".join(real_aliases)
     await bot.send(ev, msg, at_sender=True)
 
 
@@ -220,6 +228,6 @@ async def _(bot: NoneBot, ev: CQEvent):
     elif args == "关闭":
         msg = await alias.off(ev.group_id)
     else:
-        raise ValueError("matcher type error")
+        return
 
     await bot.send(ev, msg, at_sender=True)

--- a/commands/mai_base.py
+++ b/commands/mai_base.py
@@ -109,7 +109,7 @@ async def _(bot: NoneBot, ev: CQEvent):
     user = await GetOrCreateUser(bot, ev)
     code = ev.message.extract_plain_text().strip()
     if not CODE_PATTERN.fullmatch(code):
-        await bot.finish("授权码格式错误，请重新发送。", at_sender=True)
+        await bot.finish(ev, "授权码格式错误，请重新发送。", at_sender=True)
     result = await bind_lxns(user, code)
     await bot.send(ev, result, at_sender=True)
 
@@ -145,7 +145,7 @@ async def _(bot: NoneBot, ev: CQEvent):
     args = ev.message.extract_plain_text().strip()
     theme_ = Theme.get_by_index(args)
     if theme_ is None:
-        await bot.finish(f"未找到该主题：\n{Theme.get_help()}", at_sender=True)
+        await bot.finish(ev, f"未找到该主题：\n{Theme.get_help()}", at_sender=True)
 
     await update_user(user.qqid, theme=theme_)
     await bot.send(ev, f"主题已切换为：「{theme_.value}」", at_sender=True)
@@ -207,10 +207,15 @@ async def _(bot: NoneBot, ev: CQEvent):
     else:
         type_ = ["SD", "DX"]
     level = match.group(3)
-    if match.group(2) == "":
-        songs = mai.total_list.filter(level=level, type=type_)
-    else:
-        songs = mai.total_list.filter(level=level, type=type_)
+    color = match.group(2)
+    songs = mai.total_list.filter(level=level, type=type_)
+    if color:
+        ci = "绿黄红紫白".index(color)
+        songs = [
+            s
+            for s in songs
+            if len(s.difficulties) > ci and s.difficulties[ci].level == level
+        ]
     if len(songs) == 0:
         result = "没有这样的乐曲哦。"
     else:
@@ -232,10 +237,10 @@ async def _(bot: NoneBot, ev: CQEvent):
         score = int(score)
 
     if rating and rating not in LEVEL_LIST:
-        await bot.finish(ev, "无此等级", reply_message=True)
+        await bot.finish(ev, "无此等级", at_sender=True)
 
     data = await draw_rise_score_list(user, rating, score)
-    await bot.send(ev, data, reply_message=True)
+    await bot.send(ev, data, at_sender=True)
 
 
 @rating_ranking
@@ -261,3 +266,4 @@ async def _(bot: NoneBot, ev: CQEvent):
         if rank.username == info.username:
             result = f"您的Rating为「{rank.ra}」，排名第「{num + 1}」名"
             await bot.finish(ev, result, at_sender=True)
+    await bot.finish(ev, "未在查分器排行榜中找到您的记录。", at_sender=True)

--- a/commands/mai_score.py
+++ b/commands/mai_score.py
@@ -88,14 +88,13 @@ async def _(bot: NoneBot, ev: CQEvent):
             await bot.finish(ev, msg.strip(), at_sender=True)
         else:
             song = mai.total_list.by_id(alias[0].song_id)
+    if song is None:
+        await bot.finish(ev, "未找到曲目", at_sender=True)
+    if level_index >= len(song.difficulties):
+        await bot.finish(ev, "该乐曲没有这个等级", at_sender=True)
     stats = song.difficulties[level_index].stats
-
     if not stats:
         await bot.finish(ev, "该乐曲还没有统计信息", at_sender=True)
-    if len(song.difficulties) == 4 and level_index == 4:
-        await bot.finish(ev, "该乐曲没有这个等级", at_sender=True)
-    if not song.difficulties[level_index]:
-        await bot.finish(ev, "该等级没有统计信息", at_sender=True)
 
     info = dedent(f"""\
         游玩次数：{round(stats.cnt)}
@@ -137,6 +136,8 @@ async def _(bot: NoneBot, ev: CQEvent):
             chart_id = int(result.group(2))
             line = float(args[-1])
             song = mai.total_list.by_id(chart_id)
+            if song is None or level_index >= len(song.difficulties):
+                raise ValueError
             chart = song.difficulties[level_index]
             tap = int(chart.notes.tap)
             slide = int(chart.notes.slide)

--- a/commands/mai_search.py
+++ b/commands/mai_search.py
@@ -27,7 +27,7 @@ async def _(bot: NoneBot, ev: CQEvent):
         await bot.finish(
             ev,
             "没有找到这样的乐曲。\n※ 如果是别名请使用「XXX是什么歌」指令进行查询哦。",
-            reply_message=True,
+            at_sender=True,
         )
 
     if len(songs) == 1:
@@ -39,7 +39,7 @@ async def _(bot: NoneBot, ev: CQEvent):
         image = MessageSegment.text(r)
     else:
         image = await draw_song_list(songs, page)
-    await bot.send(ev, image, reply_message=True)
+    await bot.send(ev, image, at_sender=True)
 
 
 @search_alias_song
@@ -65,7 +65,7 @@ async def _(bot: NoneBot, ev: CQEvent):
             msg += "※ 可以使用指令「同意别名 XXXXX」进行投票"
             await bot.finish(ev, msg.strip(), at_sender=True)
         else:
-            alias_data = yuzu_alias_to_alias(obj)
+            alias_data = yuzu_alias_to_alias(obj.data)
     if alias_data:
         if len(alias_data) != 1:
             msg = f"找到{len(alias_data)}个相同别名的曲目：\n"
@@ -86,8 +86,12 @@ async def _(bot: NoneBot, ev: CQEvent):
         await bot.finish(
             ev, "您要找的是不是：" + (await draw_chart_info(song, user)), at_sender=True
         )
-    if search_id := re.search(r"^id([0-9]*)$", name, re.IGNORECASE):
+    if search_id := re.search(r"^id([0-9]+)$", name, re.IGNORECASE):
         song = mai.total_list.by_id(int(search_id.group(1)))
+        if not song:
+            await bot.finish(
+                ev, f"未找到ID为「{search_id.group(1)}」的乐曲", at_sender=True
+            )
         await bot.finish(
             ev, "您要找的是不是：" + (await draw_chart_info(song, user)), at_sender=True
         )
@@ -121,7 +125,7 @@ async def _(bot: NoneBot, ev: CQEvent):
     _id = match.group(1)
     song = mai.total_list.by_id(int(_id))
     if not song:
-        msg = f"未找到ID为「{id}」的乐曲"
+        msg = f"未找到ID为「{_id}」的乐曲"
     else:
         msg = await draw_chart_info(song, user)
     await bot.send(ev, msg)

--- a/commands/mai_table.py
+++ b/commands/mai_table.py
@@ -31,7 +31,7 @@ TABLE_PATTERN = (
 LEVEL_PATTERN = (
     r"^([0-9]+\+?)\s?((?:a+|b+|c|d|s+|ap|fc|fs|fdx)\+?)\s?([\u4e00-\u9fa5]+)?\s?进度\s?([0-9]+)?$"
 )
-LEVEL_LIST_PATTERN = r"([0-9]+\.?[0-9]?\+?)\s?分数列表\s?([0-9]+)?$"
+LEVEL_LIST_PATTERN = r"^([0-9]+(?:\.[0-9]+)?\+?)\s?分数列表\s?([0-9]+)?$"
 CATEGORY_ALIAS = {
     "已完成": Category.COMPLETED,
     "未完成": Category.UNFINISHED,
@@ -97,6 +97,12 @@ async def _(bot: NoneBot, ev: CQEvent):
     if ra in LEVEL_LIST[:6]:
         await bot.finish(ev, "只支持查询lv7-15的完成表。", at_sender=True)
     elif ra in LEVEL_LIST[6:]:
+        if plan and plan.lower() not in COMBO_PLUS:
+            await bot.finish(
+                ev,
+                "完成表目前仅支持「fc」「ap」计划，例如「13fc完成表」「13ap完成表」。",
+                at_sender=True,
+            )
         pic = await draw_rating_table(
             user, ra, True if plan and plan.lower() in COMBO_PLUS else False
         )
@@ -159,7 +165,7 @@ async def _(bot: NoneBot, ev: CQEvent):
         if target_category:
             category = target_category
         else:
-            await bot.finish(ev, f"无法指定查询「{category}」", at_sender=True)
+            await bot.finish(ev, f"无法指定查询「{category_}」", at_sender=True)
     else:
         category = Category.DEFAULT
 
@@ -172,18 +178,17 @@ async def _(bot: NoneBot, ev: CQEvent):
     user = await GetUserAndAuth(bot, ev)
     match: Match[str] = ev["match"]
     if not match:
-        await bot.finish("输入错误，请重新输入指定等级。", at_sender=True)
+        await bot.finish(ev, "输入错误，请重新输入指定等级。", at_sender=True)
 
     rating = match.group(1)
     page = match.group(2) or 1
-    try:
-        if "." in rating:
-            rating = round(float(rating), 1)
-        elif rating not in LEVEL_LIST:
-            await bot.finish(ev, "无此等级", at_sender=True)
-    except ValueError:
-        if rating not in LEVEL_LIST:
-            await bot.finish(ev, "无此等级", at_sender=True)
+    if "." in rating:
+        # 定数仅有一位小数，多位小数视为输入有误
+        if not re.fullmatch(r"[0-9]+\.[0-9]", rating):
+            await bot.finish(ev, "输入有误，定数仅有一位小数。", at_sender=True)
+        rating = round(float(rating), 1)
+    elif rating not in LEVEL_LIST:
+        await bot.finish(ev, "无此等级", at_sender=True)
 
     result = await draw_level_score_list(user, rating, int(page))
     await bot.send(ev, result, at_sender=True)

--- a/config.py
+++ b/config.py
@@ -30,7 +30,11 @@ class BaseConfig(Settings):
     maimaidx_alias_push: bool = True
     save_in_memory: bool | None = True
     assets_online: bool | None = True
-    bot_name: str = NICKNAME if isinstance(NICKNAME, str) else list(NICKNAME)[0]
+    bot_name: str = (
+        NICKNAME
+        if isinstance(NICKNAME, str)
+        else (list(NICKNAME)[0] if NICKNAME else "Sakura")
+    )
 
 
 class DivingFishConfig(Settings):

--- a/core/alias_ws_push.py
+++ b/core/alias_ws_push.py
@@ -73,6 +73,8 @@ async def push_alias(push: PushAliasStatus):
         song_id = _s.song_id
         alias_name = _s.apply_alias
         song = mai.total_list.by_id(song_id)
+        if song is None:
+            continue
         if push.type == "Apply":
             message.append(
                 dedent(f"""\
@@ -123,11 +125,13 @@ async def ws_alias_server():
                         data = await ws.receive_text()
                         if data == "Hello":
                             log.info("别名推送服务器正常运行")
+                            continue
                         try:
                             newdata = json.loads(data)
                             status = PushAliasStatus.model_validate(newdata)
                             await push_alias(status)
-                        except Exception:
+                        except Exception as e:
+                            log.error(f"处理别名推送失败: {e}")
                             continue
         except (WebSocketDisconnect, httpx.LocalProtocolError) as e:
             log.warning(f"连接断开或异常: {e}，将在 60 秒后重连")

--- a/core/arcade.py
+++ b/core/arcade.py
@@ -34,12 +34,13 @@ class ArcadeList(list[Arcade]):
     def search_name(self, name: str) -> list[Arcade]:
         """模糊查询机厅"""
         arcade_list = []
+        name = name.lower()
         for arcade in self:
-            if name in arcade.name:
+            if name in arcade.name.lower():
                 arcade_list.append(arcade)
-            elif name in arcade.location:
+            elif name in arcade.location.lower():
                 arcade_list.append(arcade)
-            elif name in arcade.alias:
+            elif any(name in a.lower() for a in arcade.alias):
                 arcade_list.append(arcade)
 
         return arcade_list

--- a/core/handler.py
+++ b/core/handler.py
@@ -282,7 +282,7 @@ def get_rise_score_list(
                     level_value=diff.level_value,
                     old_rating=old_result.rating,
                     old_achievements=old_result.achievements,
-                    old_rate=old_result.rate.value,
+                    old_rate=old_result.rate.value if old_result.rate else "D",
                 )
                 rise_result.append(rise)
                 break
@@ -418,9 +418,9 @@ async def get_mai_what(user: User) -> Song | None:
     if _ra != 0:
         ds = round(_ra / 22.4, 1)
         music_list = mai.total_list.filter(level_value=(ds, ds + 1))
-        for _m in music_list:
-            if int(_m.song_id) in ignore:
-                music_list.remove(_m)
+        music_list = [m for m in music_list if int(m.song_id) not in ignore]
+        if not music_list:
+            return None
         return random.choice(music_list)
     return None
 
@@ -630,8 +630,11 @@ async def draw_level_progress(
         if plan_type == 2:  # Sync
             if not res.fs:
                 return False
-            sync_list = SYNC_D_SP if res.fs in SYNC_D_SP else SYNC_SP
-            return sync_list.index(res.fs) >= plan_value
+            if res.fs in SYNC_D_SP:
+                return SYNC_D_SP.index(res.fs) >= plan_value
+            if res.fs in SYNC_SP:
+                return SYNC_SP.index(res.fs) >= plan_value
+            return False
         return False
 
     completed: list[PlayedResult] = []
@@ -657,8 +660,14 @@ async def draw_level_progress(
                 )
 
     sort_key = {0: "achievements", 1: "fc", 2: "fs"}.get(plan_type, "achievements")
-    completed.sort(key=lambda x: getattr(x, sort_key) or "", reverse=True)
-    unfinished.sort(key=lambda x: getattr(x, sort_key) or "", reverse=True)
+    sort_default = 0 if plan_type == 0 else ""
+
+    def _sort_value(res: PlayedResult):
+        value = getattr(res, sort_key)
+        return value if value is not None else sort_default
+
+    completed.sort(key=_sort_value, reverse=True)
+    unfinished.sort(key=_sort_value, reverse=True)
     notplayed.sort(key=lambda x: x.level_value, reverse=True)
 
     if category == Category.DEFAULT:
@@ -678,9 +687,8 @@ async def draw_level_progress(
     elif category in [Category.COMPLETED, Category.UNFINISHED]:
         data = completed if category == Category.COMPLETED else unfinished
         per_page = 80
-        total_page = (len(data) - 1) // per_page + 1
-        if page > total_page:
-            page = total_page
+        total_page = max(1, (len(data) - 1) // per_page + 1)
+        page = max(1, min(page, total_page))
 
         display_data = data[(page - 1) * per_page : page * per_page]
         y_size = get_rows(len(display_data), 5) * 109
@@ -729,9 +737,8 @@ async def draw_level_score_list(
     )
 
     result_sum = len(new_play_result)
-    end_page = (result_sum + 79) // 80
-    if page > end_page:
-        page = end_page
+    end_page = max(1, (result_sum + 79) // 80)
+    page = max(1, min(page, end_page))
 
     to_page = 80 if page < end_page else (result_sum % 80 or 80)
     line = (to_page + 4) // 5

--- a/core/service/__init__.py
+++ b/core/service/__init__.py
@@ -10,6 +10,7 @@ from ..image.tools import image_to_base64, song_chart
 from ..merge import merge_alias_data, merge_music_data
 from ..merge.alias_list import AliasList
 from ..merge.models import (
+    Alias,
     AliasesPush,
     GuessDefaultData,
     GuessPicData,
@@ -231,8 +232,9 @@ class Guess:
         """猜曲绘数据"""
         song = random.choice(self._guess_data)
         pic = self._pic(song)
-        answer = mai.total_alias_list.by_id(song.song_id)[0].alias
-        answer.append(song.song_id)
+        _alias = mai.total_alias_list.by_id(song.song_id)
+        answer = [a.lower() for a in _alias[0].alias] if _alias else []
+        answer.append(str(song.song_id))
         return GuessPicData(
             song=song, img=image_to_base64(pic), answer=answer, end=False
         )
@@ -253,8 +255,9 @@ class Guess:
             ],
             6,
         )
-        answer = mai.total_alias_list.by_id(song.song_id)[0].alias
-        answer.append(song.song_id)
+        _alias = mai.total_alias_list.by_id(song.song_id)
+        answer = [a.lower() for a in _alias[0].alias] if _alias else []
+        answer.append(str(song.song_id))
         pic = self._pic(song)
         return GuessDefaultData(
             song=song,
@@ -266,7 +269,7 @@ class Guess:
 
     def end(self, gid: int):
         """结束猜歌"""
-        del self._group[gid]
+        self._group.pop(gid, None)
 
     async def on(self, gid: int) -> str:
         """开启猜歌"""
@@ -301,11 +304,24 @@ async def update_local_alias(song_id: int, alias_name: str) -> bool:
         if local_alias_file.exists():
             local_alias_data = await openfile(local_alias_file)
 
-        if song_id not in local_alias_data:
+        if song_id_key not in local_alias_data:
             local_alias_data[song_id_key] = []
+        if alias not in local_alias_data[song_id_key]:
+            local_alias_data[song_id_key].append(alias)
 
-        local_alias_data[song_id_key].append(alias)
-        mai.total_alias_list.by_id(song_id)[0].alias.append(alias)
+        entries = mai.total_alias_list.by_id(song_id)
+        if entries:
+            if alias not in entries[0].alias:
+                entries[0].alias.append(alias)
+        else:
+            _song = mai.total_list.by_id(song_id)
+            mai.total_alias_list.root.append(
+                Alias(
+                    song_id=song_id,
+                    song_name=_song.song_name if _song else "",
+                    alias=[alias],
+                )
+            )
 
         await writefile(local_alias_file, local_alias_data)
         return True

--- a/maimai_arcade.py
+++ b/maimai_arcade.py
@@ -128,12 +128,12 @@ async def _(bot: NoneBot, ev: CQEvent):
     args: list[str] = ev.message.extract_plain_text().strip().split()
     if not priv.check_priv(ev, priv.ADMIN):
         msg = "仅允许管理员修改机厅信息"
+    elif len(args) != 3 or args[1] != "数量" or not args[2].isdigit():
+        msg = "格式错误：修改机厅 <店名/ID> 数量 <数量>"
     elif not args[0].isdigit() and len(_arc := arcade.total.search_fullname(args[0])) > 1:
         msg = "找到多个相同店名的机厅，请使用店铺ID修改机厅\n" + "\n".join([ f"{_.id}：{_.name}" for _ in _arc ])
-    elif args[1] == "数量" and len(args) == 3 and args[2].isdigit():
-        msg = await updata_arcade(args[0], args[2])
     else:
-        msg = "格式错误：修改机厅 <店名> [数量] <数量>"
+        msg = await updata_arcade(args[0], args[2])
     
     await bot.send(ev, msg, at_sender=True)
 
@@ -204,7 +204,8 @@ async def _(bot: NoneBot, ev: CQEvent):
         if not arcade_list:
             await bot.finish(ev, "该群未订阅机厅，无法更改机厅人数", at_sender=True)
         value = match.group(2)
-        person = int(match.group(3))
+        _amount = match.group(3)
+        person = 1 if _amount in ["＋", "+", "－", "-"] else int(_amount)
         if match.group(1):
             if "人数" in match.group(1) or "卡" in match.group(1):
                 arcadeName = match.group(1)[:-2] if "人数" in match.group(1) else match.group(1)[:-1]


### PR DESCRIPTION
修复了一批指令、机厅排卡及共用核心逻辑中的 bug，均不改变正常路径行为，仅补齐异常/边界处理。

### 崩溃 / 无响应
- **猜歌 / 猜曲绘**：`answer` 把 int 类型 `song_id` 追加进 `list[str]` 字段，pydantic v2 默认不转换 → 构造模型即 `ValidationError`，**一开局就崩**。改为追加 `str(song_id)`，并复制+小写别名列表（同时修复污染全局别名缓存、答案大小写不匹配、`by_id` 空表三个隐患）。
- **授权码 / 主题 / 分数列表**：`bot.finish(...)` 漏传首个 `ev` 参数 → 框架报错。已补全。
- **查歌 / 定数 / bpm / 曲师 / 谱师查歌**：对用户输入直接 `int()/float()` 未校验（如 `查歌 Love You`）→ 未捕获 `ValueError`。改为校验数字、支持含空格的标题/曲师/谱师名。
- **id是什么歌**：`^id([0-9]*)$` 让裸 `id` 空组匹配 → `int('')` 崩溃，改为 `[0-9]+`；命中不存在曲目时提示未找到。
- **ginfo / 分数线**：难度越界（4 难度曲查「白」）`IndexError`。改为先做越界/None 检查。
- **等级进度**：`sync` 判定 → `SYNC_SP.index('sync')` `ValueError`；0% 成绩排序 `TypeError`；非法分类提示引用了未定义变量 `category`（应为 `category_`）→ `NameError`。均已修正。
- **全局开启/关闭别名推送**：`on_suffix("别名推送")` 同时命中，后缀处理器 `else: raise ValueError`。改为静默返回，并收紧全局正则。
- **修改机厅**：不校验参数长度就取 `args[0]/args[1]` → `IndexError`（如 `修改机厅 12345`）。改为先校验长度。

### 逻辑 / 输出错误
- **添加本地别名**：int 与 JSON str 键比较恒真 → 每次新增覆盖旧别名；无别名曲首个别名 `IndexError`。已修正。
- **猜歌 Guess.end**：无保护 `del` → 计时结束与正确猜中竞态 `KeyError`，改 `pop`。
- **添加别名 / 同意别名**：直接发送 `MessageResult` 对象（用户看到 `message='…'` repr），改取 `.message`；同意别名捕获所有异常。
- **id`<数字>`**：未找到提示误用内置 `id`，改为 `_id`。
- **查歌别名分支**：`yuzu_alias_to_alias(obj)` 传了整个对象，改为 `obj.data`。
- **XXX有什么别名**：`id` 前缀仅在其后为空格/数字时才作标志（修复 `idol`/`Idola` 被误剥）；`by_id` 传 int；过滤与标题同名的伪别名。
- **完成表**：`s/fs/fdx` 等不支持的计划改为明确提示。
- **当前投票**：页数 off-by-one，改用向上取整。
- **我的排名**：未上榜时给出提示而非静默。
- **随机谱面**：真正按难度颜色筛选（原 if/else 两分支相同）。
- **机厅排卡 +/-**：裸 `+/-` 符号视为 ±1，避免 `int('+')` 被静默吞掉。
- **机厅查找**：`search_name` 改为大小写不敏感、别名子串匹配（原为精确匹配且区分大小写）。
- `reply_message` 残留 kwarg 统一改为 `at_sender`。

### 其它
- **别名推送 WS**：跳过曲库中不存在的曲目（避免推送静默丢失），异常改为记录日志。
- **config**：`NICKNAME` 为空集合时回退默认名，避免启动 `IndexError`。
